### PR TITLE
Add t/strace_bug.t.

### DIFF
--- a/t/strace_bug.t
+++ b/t/strace_bug.t
@@ -17,8 +17,8 @@ sub tclass { 'My::Trace' }
 
 use Test::More tests => 3;
 eval {
-    eval "use Foo::Bar::Baz" or My::X->throw(message => 'WTF!');
+    eval "die 'Previously'" or My::X->throw(message => 'WTF!');
 };
 is $@->message, 'WTF!', 'Should have message';
-isnt $@->previous_exception, undef, 'Should have previous exception';
+like $@->previous_exception, qr/Previously/, 'Should have previous exception';
 isa_ok $@->stack_trace_class, 'My::Trace';


### PR DESCRIPTION
On Perl 5.17.0, `previous_exception` is intermittently undefined. Note that
the test uses its own stack trace class that does nothing, not
Devel::StackTrace.
