### PR TITLE
Add an easy way to extend stack_trace_args

### DIFF
--- a/lib/StackTrace/Auto.pm
+++ b/lib/StackTrace/Auto.pm
@@ -107,7 +107,23 @@ sub _build_stack_trace_args {
         return 0;
       }
     },
+    $self->extra_stack_trace_args,
   ];
+}
+
+=method extra_stack_trace_args
+
+Setting 'stack_trace_args' directly can be a little bit tricky because you
+don't want to stamp on our default filter that hides the stack trace building
+process from the generated stack trace. Instead, implement
+C<extra_stack_trace_args> which should return a list of extra parameters to
+pass to the stack trace class's C<new> method along with the default frame
+filter.
+
+=cut
+
+sub extra_stack_trace_args {
+  return;
 }
 
 sub _build_stack_trace {

--- a/t/basic.t
+++ b/t/basic.t
@@ -16,6 +16,12 @@ BEGIN {
     use $class;
     extends 'Throwable::Error';
 
+    sub extra_stack_trace_args {
+      return (
+        message => "Overridden message",
+      );
+    }
+
     1;
   } or die $@;
 }
@@ -39,6 +45,7 @@ is($error->message, q{foo bar baz}, "error message is correct");
 my $trace = $error->stack_trace;
 
 isa_ok($trace, 'Devel::StackTrace', 'the trace');
+like $trace->as_string, qr/^Overridden message/, "Stack trace args extended";
 
 my @frames = $trace->frames;
 is(@frames, 4 + $extra_frames, "we have four frames in our trace");
@@ -46,6 +53,7 @@ is($frames[0]->subroutine, q{Throwable::throw},   'correct frame 0');
 is($frames[1]->subroutine, q{main::throw_x},      'correct frame 1');
 is($frames[2]->subroutine, q{main::call_throw_x}, 'correct frame 2');
 is($frames[3]->subroutine, q{(eval)},             'correct frame 3');
+
 
 {
    eval { MyError->throw('shucks howdy'); };


### PR DESCRIPTION
It's easy to accidentally stomp on the frame_filter that hides the
machinery of StackTrace::Auto from the generated stack trace, so we add
an overrideable `extra_stack_trace_args` method to the role. Then
consuming roles and classes can add to the argument list without having
to either subclass Devel::Stacktrace, copy/paste the default filter
code, or wrap/call a private method (`_build_stack_trace_args`).

I'm not sure the documentation is quite what it could be, and I'm in two
minds about whether to try and be clever if one of the keys in 
`extra_stack_trace_args` is `frame_filter` (though I lean towards trusting 
(handing enough rope to) anyone who wants to write their own `frame_filter`
and getting out of the way.)
