### PR TITLE
Throwable/Error.pm: Change POD, class is now built on Moo

### DIFF
--- a/lib/StackTrace/Auto.pm
+++ b/lib/StackTrace/Auto.pm
@@ -8,9 +8,10 @@ use Scalar::Util ();
 
 =head1 SYNOPSIS
 
-First, include StackTrace::Auto in a Moose class...
+First, include StackTrace::Auto in a Moose/Moo/Mouse class...
 
   package Some::Class;
+  # NOTE: Moo/Mouse can also be used here instead of Moose
   use Moose;
   with 'StackTrace::Auto';
 

--- a/lib/Throwable.pm
+++ b/lib/Throwable.pm
@@ -9,6 +9,7 @@ use Carp ();
 =head1 SYNOPSIS
 
   package Redirect;
+  # NOTE: Moo/Mouse can also be used here instead of Moose
   use Moose;
   with 'Throwable';
 
@@ -25,7 +26,7 @@ standard program flow.  It is very simple and does only two things: saves any
 previous value for C<$@> and calls C<die $self>.
 
 Throwable is implemented with L<Moo>, so you can stick to Moo or use L<Moose>
-as you prefer.
+or L<Mouse>, as you prefer.
 
 =attr previous_exception
 

--- a/lib/Throwable/Error.pm
+++ b/lib/Throwable/Error.pm
@@ -32,7 +32,7 @@ with 'Throwable', 'StackTrace::Auto';
 Throwable::Error is a base class for exceptions that will be thrown to signal
 errors and abort normal program flow.  Throwable::Error is an alternative to
 L<Exception::Class|Exception::Class>, the features of which are largely
-provided by the Moose object system atop which Throwable::Error is built.
+provided by the Moo object system atop which Throwable::Error is built.
 
 Throwable::Error performs the L<Throwable|Throwable> and L<StackTrace::Auto>
 roles.  That means you can call C<throw> on it to create and throw an error

--- a/lib/Throwable/Error.pm
+++ b/lib/Throwable/Error.pm
@@ -7,6 +7,7 @@ with 'Throwable', 'StackTrace::Auto';
 =head1 SYNOPSIS
 
   package MyApp::Error;
+  # NOTE: Moo/Mouse can also be used here instead of Moose
   use Moose;
   extends 'Throwable::Error';
 


### PR DESCRIPTION
I'd be more than happy to update the examples in the POD of all of the classes so they show either Moose or Moo being used with Throwable, but I'm not sure if that's desired, and if it is, what the best way to show both classes being able to consume the Throwable role.

If you do want to show both Moo and Moose being used, I could show two sets of examples, or maybe put comments behind the "use Moose;" lines to note that Moo would also work there too.  Or maybe something else?