### PR TITLE
Add boolean overload to Throwable::Error

### DIFF
--- a/lib/Throwable/Error.pm
+++ b/lib/Throwable/Error.pm
@@ -44,6 +44,7 @@ creation.
 
 use overload
   q{""}    => 'as_string',
+  bool     => sub {1},
   fallback => 1;
 
 =attr message


### PR DESCRIPTION
Error objects should never evaluate to false even if the error message is empty or 0. An explicit overload will ensure this.